### PR TITLE
Support for errbit

### DIFF
--- a/ExceptionHandler.cs
+++ b/ExceptionHandler.cs
@@ -83,6 +83,8 @@ namespace airbrake
             XmlDeclaration dec = doc.CreateXmlDeclaration("1.0", "UTF-8", null);
             doc.AppendChild(dec);
             XmlElement root = doc.CreateElement("notice");
+            root.SetAttribute("version", "2.3");
+
 
             //API Key
             XmlElement apikey = doc.CreateElement("api-key");


### PR DESCRIPTION
I tried using this with [errbit](https://github.com/errbit/errbit) and it had issues because it expects an API version to be sent. 

So I made it send a version number along with the request, I am not sure if 2.3 was the correct version but it was one accepted by errbit and it all seems to work now. Its only a tiny modification but it might be useful for anyone trying to use this with errbit (and possibly anything else that uses the airbrake API) 
I am not sure if this causes any issues with Airbrake but I would assume it doesn't.
